### PR TITLE
Updated aws_region data source to fix deprecation warning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 2.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [2.0.0](https://github.com/plus3it/terraform-aws-tardigrade-ssm-default-host-management/releases/tag/2.0.0)
+
+**Released**: 2025.10.14
+
+**Summary**:
+
+*   Updates aws_region data source to fix deprecation warning (Requires aws provider v6)
+*   Sets v6 as the min version for the aws provider
+
 ### [1.0.1](https://github.com/plus3it/terraform-aws-tardigrade-ssm-default-host-management/releases/tag/1.0.1)
 
 **Released**: 2025.04.09

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,3 @@
+ONLY_MOTO := true
+
 include $(shell test -f .tardigrade-ci || curl -sSL -o .tardigrade-ci "https://raw.githubusercontent.com/plus3it/tardigrade-ci/master/bootstrap/Makefile.bootstrap"; echo .tardigrade-ci)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ the same features as the [Quick Setup for Default Host Management in an AWS Orga
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.72.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.72.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachments_exclusive" "example" {
 locals {
   account_id = data.aws_caller_identity.this.account_id
   partition  = data.aws_partition.this.partition
-  region     = data.aws_region.this.name
+  region     = data.aws_region.this.region
 
   # If the default host management role name is not specified, use aws_iam_role.
   # Otherwise, use the role name provided by the user.

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.72.0"
+      version = ">= 6.0.0"
     }
   }
 }


### PR DESCRIPTION
```
│
│ Warning: Deprecated attribute
│
│   on .terraform/modules/ssm_default_host_management/main.tf line 69, in locals:
│   69:   region     = data.aws_region.this.name
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
│
```
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#argument-reference